### PR TITLE
修复设置入口以及杂项变更

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,7 +73,8 @@ extensions.configure<ApplicationExtension> {
     buildTypes {
         debug {
             signingConfig =
-                if (keystorePath.isNullOrBlank()) null else signingConfigs.getByName("ci")
+                if (keystorePath.isNullOrBlank()) signingConfigs.getByName("debug")
+                else signingConfigs.getByName("ci")
         }
         release {
             isMinifyEnabled = true

--- a/app/src/main/java/com/owo233/tcqt/hooks/func/AddModuleEntrance.kt
+++ b/app/src/main/java/com/owo233/tcqt/hooks/func/AddModuleEntrance.kt
@@ -122,8 +122,8 @@ class AddModuleEntrance : AlwaysRunAction(), DexKitTask {
 
     private fun resolveSettingProvider(mainFragmentClass: Class<*>): Pair<Class<*>, Boolean> {
         val candidates = listOf(
+            "com.tencent.mobileqq.setting.main.MainSettingConfigProvider",
             "com.tencent.mobileqq.setting.main.NewSettingConfigProvider",
-            "com.tencent.mobileqq.setting.main.MainSettingConfigProvider"
         )
 
         val entryClass = candidates
@@ -131,7 +131,7 @@ class AddModuleEntrance : AlwaysRunAction(), DexKitTask {
             ?: inferProviderFromField(mainFragmentClass)
             ?: error("未找到MainSettingFragment类中被混淆的Provider,无法创建模块设置入口!")
 
-        val isNewProvider = entryClass.name != candidates.last()
+        val isNewProvider = entryClass.name == candidates.last()
         return entryClass to isNewProvider
     }
 


### PR DESCRIPTION
1. fix: QQ9.1.60 模块设置入口消失
旧版优先 hook MainSettingConfigProvider 而不是 NewSettingConfigProvider

2. chore: debug编译类型使用默认调试签名
使用默认调试签名 方便直接 installDebug 调试安装测试
