### PR TITLE
feat: 使用系统应用选择器

### DIFF
--- a/app/src/main/java/com/owo233/tcqt/features/general/UseSystemAppPicker.kt
+++ b/app/src/main/java/com/owo233/tcqt/features/general/UseSystemAppPicker.kt
@@ -1,0 +1,40 @@
+package com.owo233.tcqt.features.general
+
+import android.app.Activity
+import android.content.Context
+import com.owo233.tcqt.annotations.RegisterAction
+import com.owo233.tcqt.api.Feature
+import com.owo233.tcqt.core.action.ActionProcess
+import com.owo233.tcqt.core.env.HookEnv.toHostClass
+import com.owo233.tcqt.core.hook.hookReplace
+import com.owo233.tcqt.core.reflect.findMethod
+import com.owo233.tcqt.core.reflect.invoke
+
+@RegisterAction
+object UseSystemAppPicker : Feature(
+    key = "use_system_app_picker",
+    name = "使用系统应用选择器",
+    desc = "将文件的“其他应用打开”交给 Android 系统处理。",
+    processes = setOf(ActionProcess.MAIN),
+) {
+
+    override fun install() {
+        val targetClass = FILE_MANAGER_UTIL_IMPL.toHostClass()
+        val systemOpenMethod = targetClass.findMethod {
+            name = "openFileWithOtherAppWithSystem"
+            paramTypes(Context::class.java, String::class.java)
+            returnType = void
+        }
+
+        targetClass.findMethod {
+            name = "openWithOtherApp"
+            paramTypes(Activity::class.java, String::class.java)
+            returnType = void
+        }.hookReplace { param ->
+            param.thisObject.invoke(systemOpenMethod, *param.args)
+        }
+    }
+
+    private const val FILE_MANAGER_UTIL_IMPL =
+        "com.tencent.mobileqq.filemanager.api.impl.FileManagerUtilImpl"
+}


### PR DESCRIPTION
## 功能

新增「使用系统应用选择器」：文件管理的「其他应用打开」不再走宿主自己的流程，改由 Android 系统选择器处理，能列出所有可打开该文件的 App 并遵循系统里已设置的默认打开方式。

## 实现

`app/src/main/java/com/owo233/tcqt/features/general/UseSystemAppPicker.kt`

- hook `com.tencent.mobileqq.filemanager.api.impl.FileManagerUtilImpl#openWithOtherApp(Activity, String)`
- 替换为调用同一个类里的 `openFileWithOtherAppWithSystem(Context, String)`，`thisObject` 与参数直接透传

## 验证

- `./gradlew :app:assembleDebug`：构建通过
- 已在 QQ 9.2.50(12670)/TIM 4.1.0(4050) 通过实机验证，QQ 9.3.65(41395) 经反编译确认 hook 点相同